### PR TITLE
Add CSS via Tailwind, Add <head> and <body> tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <script defer src="https://pyscript.net/alpha/pyscript.js"></script>
     <py-script src="./emoji_playground.py">
     </py-script>
-    <div class="p-2 bg-green-50">
+    <div class="p-2 bg-green-50 m-8 border-2">
         <div class="flex flex-row space-x-12">
             <div class="grid grid-cols-2">
                 <p class="">Select an Emoji:</p>
@@ -40,14 +40,16 @@
                 </select>
             </div>
         </div>
+    </div>
+    <div class="p-2 bg-green-50 m-8 border-2">
         <div id="images" class="flex flex-col w-auto space-x-4 border-green-300 divide-x-2 md:flex-row">
             <div class="grow">
                 <p class="w-full text-lg font-semibold text-center underline">Original Image</p>
-                <div id="original_image"></div>
+                <div id="original_image" class="justify-center flex"></div>
             </div>
             <div class="grow">
                 <p class="w-full text-lg font-semibold text-center underline">Processed Image</p>
-                <div id="new_image"></div>
+                <div id="new_image" class="justify-center flex"></div>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -1,47 +1,56 @@
 <html>
-<py-env>
-    - Pillow
-    - matplotlib
-    - scikit-image
-    - numpy
-</py-env>
-
-<script defer src="https://pyscript.net/alpha/pyscript.js"></script>
-<py-script src="./emoji_playground.py">
-</py-script>
-<div class="p-2 bg-green-50">
-    <div class="flex flex-row space-x-12">
-        <div class="grid grid-cols-2">
-            <p class="post-p">Select an Emoji:</p>
-            <select id="emoji-selector">
-                <option value="🤖">🤖</option>
-                <option value="👨‍🎨">👨‍🎨</option>
-                <option value="🧠">🧠</option>
-                <option value="🦞">🦞</option>
-                <option value="🌯">🌯</option>
-                <option value="🎭">🎭</option>
-            </select>
+<head>
+    <!--
+    Import tailwind js to dnyamical add styleing to tailwind classes
+    "Not the best choice for production" says Tailwind, but will do for now 
+    -->
+    <script src="https://cdn.tailwindcss.com/"></script>
+</head>
+<body>
+    <py-env>
+        - Pillow
+        - matplotlib
+        - scikit-image
+        - numpy
+    </py-env>
+    
+    <script defer src="https://pyscript.net/alpha/pyscript.js"></script>
+    <py-script src="./emoji_playground.py">
+    </py-script>
+    <div class="p-2 bg-green-50">
+        <div class="flex flex-row space-x-12">
+            <div class="grid grid-cols-2">
+                <p class="post-p">Select an Emoji:</p>
+                <select id="emoji-selector">
+                    <option value="🤖">🤖</option>
+                    <option value="👨‍🎨">👨‍🎨</option>
+                    <option value="🧠">🧠</option>
+                    <option value="🦞">🦞</option>
+                    <option value="🌯">🌯</option>
+                    <option value="🎭">🎭</option>
+                </select>
+            </div>
+            <div class="grid grid-cols-2">
+                <p class="post-p">Select a Filter:</p>
+                <select id="filter-selector">
+                    <option value="swirl">Swirl</option>
+                    <option value="affine">Affine Filter</option>
+                    <option value="butterworth_low">Butterworth Low Pass</option>
+                    <option value="butterworth_high">Butterworth High Pass</option>
+                </select>
+            </div>
         </div>
-        <div class="grid grid-cols-2">
-            <p class="post-p">Select a Filter:</p>
-            <select id="filter-selector">
-                <option value="swirl">Swirl</option>
-                <option value="affine">Affine Filter</option>
-                <option value="butterworth_low">Butterworth Low Pass</option>
-                <option value="butterworth_high">Butterworth High Pass</option>
-            </select>
+        <div id="images" class="flex flex-col w-auto space-x-4 border-green-300 divide-x-2 md:flex-row">
+            <div class="grow">
+                <p class="w-full text-lg font-semibold text-center underline">Original Image</p>
+                <div id="original_image"></div>
+            </div>
+            <div class="grow">
+                <p class="w-full text-lg font-semibold text-center underline">Processed Image</p>
+                <div id="new_image"></div>
+            </div>
         </div>
     </div>
-    <div id="images" class="flex flex-col w-auto space-x-4 border-green-300 divide-x-2 md:flex-row">
-        <div class="grow">
-            <p class="w-full text-lg font-semibold text-center underline">Original Image</p>
-            <div id="original_image"></div>
-        </div>
-        <div class="grow">
-            <p class="w-full text-lg font-semibold text-center underline">Processed Image</p>
-            <div id="new_image"></div>
-        </div>
-    </div>
-</div>
+</body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <div class="p-2 bg-green-50">
         <div class="flex flex-row space-x-12">
             <div class="grid grid-cols-2">
-                <p class="post-p">Select an Emoji:</p>
+                <p class="">Select an Emoji:</p>
                 <select id="emoji-selector">
                     <option value="🤖">🤖</option>
                     <option value="👨‍🎨">👨‍🎨</option>
@@ -31,7 +31,7 @@
                 </select>
             </div>
             <div class="grid grid-cols-2">
-                <p class="post-p">Select a Filter:</p>
+                <p class="">Select a Filter:</p>
                 <select id="filter-selector">
                     <option value="swirl">Swirl</option>
                     <option value="affine">Affine Filter</option>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    content: ["./src/**/*.{html,js}"],
+    theme: {
+      extend: {},
+    },
+    plugins: [],
+  }


### PR DESCRIPTION
To allow formatting of the page, add an import to the [Tailwind Play CDN](https://tailwindcss.com/docs/installation/play-cdn), which dynamically creates CSS for the tailwind classes used on a page. This brings the page formatting closer to [the original demo](https://jeff.glass/post/scikit-image-processing/), though this formatting can and should be improved.

Add a tailwind.config.js file to allow for future formatting adjustments, and to improve autocompletion in IDE's like VScode.